### PR TITLE
Make it possible to use own audit log implementations

### DIFF
--- a/src/test/java/com/floragunn/searchguard/auditlog/impl/DelegateTest.java
+++ b/src/test/java/com/floragunn/searchguard/auditlog/impl/DelegateTest.java
@@ -1,0 +1,37 @@
+package com.floragunn.searchguard.auditlog.impl;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Settings.Builder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DelegateTest  extends AbstractUnitTest  {
+	
+	protected final ESLogger log = Loggers.getLogger(this.getClass());
+
+	@Test
+	public void auditLogTypeTest() throws Exception{
+		testAuditType("DeBUg", DebugAuditLog.class);
+		testAuditType("intERnal_Elasticsearch", ESAuditLog.class);
+		testAuditType("EXTERnal_Elasticsearch", HttpESAuditLog.class);
+		testAuditType("com.floragunn.searchguard.auditlog.impl.MyOwnAuditLog", MyOwnAuditLog.class);
+		testAuditType("Com.Floragunn.searchguard.auditlog.impl.MyOwnAuditLog", null);
+		testAuditType("idonotexist", null);
+	}
+		
+	private void testAuditType(String type, Class<? extends AbstractAuditLog> expectedClass) throws Exception {
+		Builder settingsBuilder  = Settings.settingsBuilder();
+		settingsBuilder.put("searchguard.audit.type", type);
+		settingsBuilder.put("path.home", ".");
+		AuditLogImpl auditLog = new AuditLogImpl(settingsBuilder.build(), null);
+		auditLog.close();
+		if (expectedClass != null) {
+			Assert.assertTrue(auditLog.delegate.getClass().equals(expectedClass));	
+		} else {
+			Assert.assertTrue(auditLog.delegate == null);
+		}
+		
+	}
+}

--- a/src/test/java/com/floragunn/searchguard/auditlog/impl/MyOwnAuditLog.java
+++ b/src/test/java/com/floragunn/searchguard/auditlog/impl/MyOwnAuditLog.java
@@ -1,0 +1,16 @@
+package com.floragunn.searchguard.auditlog.impl;
+
+import java.io.IOException;
+
+public class MyOwnAuditLog extends AbstractAuditLog {
+
+	@Override
+	public void close() throws IOException {
+		
+	}
+
+	@Override
+	protected void save(AuditMessage msg) {
+	}
+
+}


### PR DESCRIPTION
Make it possible to use own audit log implementations. If customers want to ship audit logs to some system other than ES, they can extend from AbstractAuditLog and use the FQN of this implementation in the configuration.
